### PR TITLE
V1.0.2

### DIFF
--- a/.github/workflows/crawler-quarter.yml
+++ b/.github/workflows/crawler-quarter.yml
@@ -1,0 +1,32 @@
+name: Crawler Proxy Pool (Quarter)
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - release
+  schedule:
+    - cron: '0,15,30,45 * * * *'
+
+jobs:
+  fatezero:
+    name: Crawler Proxy Pool - FateZero
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ secrets.BRANCH }}
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+      - name: Install Packages
+        run: pip install -r requirements.txt
+      - name: Run Script
+        env:
+          application_id: ${{ secrets.APPLICATION_ID }}
+          rest_key: ${{ secrets.REST_KEY }}
+          target: 'fatezero'
+          protocol: 'HTTP'
+        run: python main_crawler.py

--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -1,4 +1,4 @@
-name: Crawler Proxy Pool
+name: Crawler Proxy Pool (Hour)
 on:
   pull_request:
     types:
@@ -27,7 +27,9 @@ jobs:
         env:
           application_id: ${{ secrets.APPLICATION_ID }}
           rest_key: ${{ secrets.REST_KEY }}
-        run: python main_crawler_yundaili.py
+          target: 'yundaili'
+          protocol: 'HTTP'
+        run: python main_crawler.py
   yundaili_free:
     name: Crawler Proxy Pool - YunDailiFree
     runs-on: ubuntu-latest
@@ -46,7 +48,9 @@ jobs:
         env:
           application_id: ${{ secrets.APPLICATION_ID }}
           rest_key: ${{ secrets.REST_KEY }}
-        run: python main_crawler_yundailifree.py
+          target: 'yundaili_free'
+          protocol: 'HTTP'
+        run: python main_crawler.py
   jiangxianli:
     name: Crawler Proxy Pool - Jiangxianli
     runs-on: ubuntu-latest
@@ -65,4 +69,6 @@ jobs:
         env:
           application_id: ${{ secrets.APPLICATION_ID }}
           rest_key: ${{ secrets.REST_KEY }}
-        run: python main_crawler_jiangxianli.py
+          target: 'jiangxianli'
+          protocol: 'HTTPS'
+        run: python main_crawler.py

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Python: Current File",
+            "name": "Python: Run",
             "type": "python",
             "request": "launch",
             "program": "${file}",

--- a/base/domain/use_proxy.py
+++ b/base/domain/use_proxy.py
@@ -23,7 +23,7 @@ class UseProxy:
         return {
             'ip': self.ip,
             'port': self.port,
-            'protocol': self.protocol,
+            'protocol': self.protocol.upper(),
             'anonymity': self.anonymity,
             'score': self.score
         }

--- a/base/utils/bmobutils.py
+++ b/base/utils/bmobutils.py
@@ -39,7 +39,7 @@ def delete_proxy(proxy:UseProxy) -> None:
     logi(data)
     if data and len(data) > 0:
         proxy.score = data[0]['score'] - 1
-        if proxy.score > 0:
+        if proxy.score > 80:
             bmob.update(classname, data[0]['objectId'], proxy.dict())
         else:
             bmob.remove(classname, data[0]['objectId'])

--- a/crawler/__init__.py
+++ b/crawler/__init__.py
@@ -9,8 +9,9 @@ Time: 2022/3/6 12:56
 version: 1.0
 """
 
-__all__ = ['JiangXianLi', 'YunDaiLi', 'YunDaiLiFree']
+__all__ = ['JiangXianLi', 'YunDaiLi', 'YunDaiLiFree', 'FateZero']
 
 from crawler.jiangxianli import JiangXianLi
 from crawler.yundaili import YunDaiLi
 from crawler.yundaili_free import YunDaiLiFree
+from crawler.fatezero import FateZero

--- a/crawler/fatezero.py
+++ b/crawler/fatezero.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""
+File Name: fatezero.py
+Author: Pengcc
+Email: pcc_pengcc@163.com
+Time: 2022/5/27 23:03
+version: 1.0
+"""
+from __future__ import annotations
+from base import *
+import time
+from verify import *
+from typing import List
+import random
+
+
+def parse_and_verify(html: str) -> bool | None:
+    """
+    get ip data
+    :param html: source code
+    :return: ip data
+    """
+
+    data = html.split('\n')
+
+    if not len(data):
+        return True
+
+    for d in data:
+        d = eval(d)
+        proxy = UseProxy(d['host'], d['port'], d['type'])
+        logi(f'{proxy.dict()} 开始验证')
+        if is_valided_proxy(proxy) and verify_ip_validity(proxy):
+            logi(f'{proxy.dict()} 验证通过')
+            add_proxy(proxy)
+        else:
+            logi(f'{proxy.dict()} 验证失败')
+
+
+class FateZero:
+    url = 'http://proxylist.fatezero.org/proxy.list'
+    interval = 5
+
+    def get_html(self, proxy: UseProxy | None) -> str | None:
+        """
+        get html source code
+        :param proxy: proxy ip
+        :param page: url param
+        :return: html source code
+        """
+        proxies = None
+        if proxy:
+            logi(proxy.proxies())
+            proxies = proxy.proxies()
+        try:
+            return get('http', url=self.url, proxies=proxies).text
+        except Exception as ex:
+            loge(ex)
+            pass
+
+    def crawler(self, proxies: List[UseProxy]) -> None:
+        """
+        save to file
+        :param proxies: proxy list
+        :return: None
+        """
+        proxy = None
+        data_list = None
+        count = 0
+        while data_list is None:
+            if len(proxies) > 0:
+                proxy = random.sample(proxies, 1)[0]
+            data_list = self.get_html(proxy)
+            count += 1
+            if data_list is None:
+                logi(f'wait {self.interval} seconds, retry ...')
+                time.sleep(self.interval)
+            if count > 3:
+                break
+        parse_and_verify(data_list)

--- a/crawler/fatezero.py
+++ b/crawler/fatezero.py
@@ -28,6 +28,8 @@ def parse_and_verify(html: str) -> bool | None:
     if not len(data):
         return True
 
+    data.pop(len(data) - 1)
+
     for d in data:
         d = eval(d)
         proxy = UseProxy(d['host'], d['port'], d['type'])

--- a/crawler/jiangxianli.py
+++ b/crawler/jiangxianli.py
@@ -84,13 +84,17 @@ class JiangXianLi:
         proxy = None
         while True:
             html = None
+            count = 0
             while html is None:
                 if len(proxies) > 0:
                     proxy = random.sample(proxies, 1)[0]
                 html = self.get_html(proxy, page)
+                count += 1
                 if html is None:
                     logi(f'wait {self.interval} seconds, retry page num {page}')
                     time.sleep(self.interval)
+                if count > 3:
+                    break
             if parse_and_verify(html):
                 break
 

--- a/crawler/jiangxianli.py
+++ b/crawler/jiangxianli.py
@@ -95,7 +95,7 @@ class JiangXianLi:
                     time.sleep(self.interval)
                 if count > 3:
                     break
-            if parse_and_verify(html):
+            if count > 3 or parse_and_verify(html):
                 break
 
             page += 1

--- a/crawler/yundaili.py
+++ b/crawler/yundaili.py
@@ -44,15 +44,15 @@ def parse_and_verify(html: str) -> None:
 
 
 class YunDaiLi:
-
-    url = 'http://www.ip3366.net'
+    url = 'http://www.ip3366.net/?stype={stype}&page=1'
     interval = 5
 
-    def get_html(self, proxy: UseProxy | None) -> str | None:
+    # def get_html(self, proxy: UseProxy | None, stype: int) -> str | None:
+    def get_html(self, proxy: UseProxy | None, stype: int) -> str | None:
         """
         get html source code
         :param proxy: proxy ip
-        :param page: url param
+        :param stype: url param
         :return: html source code
         """
         proxies = None
@@ -60,7 +60,7 @@ class YunDaiLi:
             logi(proxy.proxies())
             proxies = proxy.proxies()
         try:
-            return get('http', url=self.url, proxies=proxies).content.decode('gb2312')
+            return get('http', url=self.url.format(stype=stype), proxies=proxies).content.decode('gb2312')
         except Exception as ex:
             loge(ex)
             pass
@@ -73,11 +73,18 @@ class YunDaiLi:
         """
         proxy = None
         html = None
-        while html is None:
-            if len(proxies) > 0:
-                proxy = random.sample(proxies, 1)[0]
-            html = self.get_html(proxy)
-            if html is None:
-                logi(f'wait {self.interval} seconds, retry ...')
-                time.sleep(self.interval)
-        parse_and_verify(html)
+        for stype in range(1, 6):
+            count = 0
+            while html is None:
+                if len(proxies) > 0:
+                    proxy = random.sample(proxies, 1)[0]
+                html = self.get_html(proxy, stype)
+                count += 1
+                if html is None:
+                    logi(f'wait {self.interval} seconds, retry ...')
+                    time.sleep(self.interval)
+                if count > 3:
+                    break
+            parse_and_verify(html)
+            logi(f'wait {self.interval} seconds, start stype num {stype}')
+            time.sleep(self.interval)

--- a/crawler/yundaili_free.py
+++ b/crawler/yundaili_free.py
@@ -44,11 +44,10 @@ def parse_and_verify(html: str) -> None:
 
 
 class YunDaiLiFree:
-
-    url = 'http://www.ip3366.net/free'
+    url = 'http://www.ip3366.net/free/?stype={stype}&page=1'
     interval = 5
 
-    def get_html(self, proxy: UseProxy | None) -> str | None:
+    def get_html(self, proxy: UseProxy | None, stype: int) -> str | None:
         """
         get html source code
         :param proxy: proxy ip
@@ -60,7 +59,7 @@ class YunDaiLiFree:
             logi(proxy.proxies())
             proxies = proxy.proxies()
         try:
-            return get('http', url=self.url, proxies=proxies).content.decode('gb2312')
+            return get('http', url=self.url.format(stype=stype), proxies=proxies).content.decode('gb2312')
         except Exception as ex:
             loge(ex)
             pass
@@ -73,11 +72,18 @@ class YunDaiLiFree:
         """
         proxy = None
         html = None
-        while html is None:
-            if len(proxies) > 0:
-                proxy = random.sample(proxies, 1)[0]
-            html = self.get_html(proxy)
-            if html is None:
-                logi(f'wait {self.interval} seconds, retry ...')
-                time.sleep(self.interval)
-        parse_and_verify(html)
+        for stype in range(1, 6):
+            count = 0
+            while html is None:
+                if len(proxies) > 0:
+                    proxy = random.sample(proxies, 1)[0]
+                html = self.get_html(proxy, stype)
+                count += 1
+                if html is None:
+                    logi(f'wait {self.interval} seconds, retry ...')
+                    time.sleep(self.interval)
+                if count > 3:
+                    break
+            parse_and_verify(html)
+            logi(f'wait {self.interval} seconds, start stype num {stype}')
+            time.sleep(self.interval)

--- a/main_crawler.py
+++ b/main_crawler.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""
+File Name: main_crawler.py
+Author: Pengcc
+Email: pcc_pengcc@163.com
+Time: 2022/5/27 22:55
+version: 1.0
+"""
+from base import *
+from crawler import *
+import os
+
+target = os.environ.get('target')
+protocol = os.environ.get('protocol')
+
+proxy = UseProxy(protocol=protocol)
+proxies = find_proxy(proxy)
+
+if target == 'yundaili':
+    YunDaiLi().crawler(proxies)
+elif target == 'yundaili_free':
+    YunDaiLiFree().crawler(proxies)
+elif target == 'jiangxianli':
+    JiangXianLi().crawler(proxies)
+elif target == 'fatezero':
+    FateZero().crawler(proxies)

--- a/main_crawler_fatezero.py
+++ b/main_crawler_fatezero.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""
+File Name: main_crawler_fatezero.py
+Author: Pengcc
+Email: pcc_pengcc@163.com
+Time: 2022/5/28 0:04
+version: 1.0
+"""
+from base import *
+from crawler import *
+
+proxy = UseProxy(protocol='HTTP')
+proxies = find_proxy(proxy)
+
+FateZero().crawler(proxies)

--- a/main_verify.py
+++ b/main_verify.py
@@ -15,10 +15,13 @@ proxies = find_proxy()
 use_proxy_list = []
 
 for proxy in proxies:
+    logi(f'{proxy.dict()} 开始验证')
     if verify_ip_validity(proxy):
+        logi(f'{proxy.dict()} 验证通过')
         add_proxy(proxy)
         use_proxy_list.append(proxy)
     else:
+        logi(f'{proxy.dict()} 验证失败')
         delete_proxy(proxy)
-
+        
 print(use_proxy_list)

--- a/verify/verify.py
+++ b/verify/verify.py
@@ -77,9 +77,10 @@ def verify_ip_validity(proxy: UseProxy) -> bool:
             return False
         if json.loads(content)['origin'].find(',') == -1:
             proxy.anonymity = '匿名'
+            return True
         else:
             proxy.anonymity = '透明'
-        return True
+            return False
     except Exception as ex:
         loge(ex)
         return False


### PR DESCRIPTION
A 有效代理新增分数字段

第一次验证通过，给相应的代理100分
在后面的验证中，每失败一次，扣1分

A 新增yundaili、yundailifree和jiangxianli的请求次数限制

超过指定次数直接结束

A 新增代理源

- [fatezero](http://proxylist.fatezero.org/)

F 修正查询代理是否入库

F 修正按条件查询不到数据问题

F 修正验证失败不扣分

F 修改yundaili和yundailifree的链接，增加stype Url参数

定时爬取yundaili和yundailifree不同stype的第一页

F 修改代理最低分数为80分

即80分以下的代理将被删除

F 修正指定代理的类型以大写保存

F 修正存储代理时不对透明代理进行存储

F 修正fatezero的数据列表最后一个为空的问题